### PR TITLE
Server log setup for NODE_ENV = dev

### DIFF
--- a/server/manifest.js
+++ b/server/manifest.js
@@ -59,3 +59,10 @@ module.exports = {
     ]
 
 };
+
+if( process.env.NODE_ENV == 'dev' ){
+    module.exports.server.debug = {
+        log: ['error', 'implementation', 'internal'],
+        request: ['error', 'implementation', 'internal']
+    };
+}

--- a/server/manifest.js
+++ b/server/manifest.js
@@ -60,7 +60,7 @@ module.exports = {
 
 };
 
-if( process.env.NODE_ENV == 'dev' ){
+if ( process.env.NODE_ENV === 'dev' ) {
     module.exports.server.debug = {
         log: ['error', 'implementation', 'internal'],
         request: ['error', 'implementation', 'internal']


### PR DESCRIPTION
fixes #18 by enabling the `error`, `implementation`, and `internal` tags for server.log() and request.log() when in the dev NODE_ENV.