### PR TITLE
Swagger autopopulate JWT with jQuery =( (=

### DIFF
--- a/server/plugins/swagger/swagger.html
+++ b/server/plugins/swagger/swagger.html
@@ -129,6 +129,14 @@
 
                 */
                   
+                window.swaggerUi.load();
+
+                function log() {
+                    if ('console' in window) {
+                        console.log.apply(console, arguments);
+                    }
+                }
+                  
                 // Autopopulate localstorage JWT
 
                 var toastElement = document.createElement('div');
@@ -198,15 +206,6 @@
                 }, 1500);
 
                 // End autopopulate code
-
-
-                window.swaggerUi.load();
-
-                function log() {
-                    if ('console' in window) {
-                        console.log.apply(console, arguments);
-                    }
-                }
             });
 
         </script>

--- a/server/plugins/swagger/swagger.html
+++ b/server/plugins/swagger/swagger.html
@@ -182,7 +182,7 @@
                         var $responseCode = $loginPostLogin.find('.response_body code');
 
                         if($responseCode.length > 0) {
-                            $responseCode[0].innerText = '';
+                            $responseCode.parent()[0].removeChild($responseCode[0]);
                         }
 
                         var watchForLoginResponse = setInterval(function() {

--- a/server/plugins/swagger/swagger.html
+++ b/server/plugins/swagger/swagger.html
@@ -128,6 +128,76 @@
                 $('#input_apiKey').val(apiKey);
 
                 */
+                  
+                // Autopopulate localstorage JWT
+
+                var toastElement = document.createElement('div');
+                toastElement.style.position = 'fixed';
+                toastElement.style.top = '0';
+                toastElement.style.fontWeight = 'bold';
+                toastElement.style.width = '80%';
+                toastElement.style.left = '50%';
+                toastElement.style.transform = 'translate(-50%, 0)';
+                toastElement.style.backgroundColor = 'rgba(255,255,255,0.95)';
+                toastElement.style.padding = '20px';
+                toastElement.style.border = '1px solid black';
+                toastElement.style.zIndex = '100';
+                toastElement.style.fontFamily = 'Verdana';
+
+                function showToast(withText) {
+                    toastElement.innerHTML = withText;
+                    document.body.appendChild(toastElement);
+                    $(toastElement).slideDown();
+
+                    setTimeout(function() {
+                        $(toastElement).slideUp();
+                    }, 2500);
+                }
+
+                setTimeout(function() {
+
+                    function populateAuthElements() {
+                        var savedJwt = localStorage.getItem('swagger-jwt');
+                        if(savedJwt !== null) {
+                            Array.prototype.slice.call($('[name="authorization"]')).forEach(function(authField) {
+                                $(authField).val(savedJwt);
+                            });
+                        }
+                    }
+
+                    var $loginPostLogin = $('#login_postLogin');
+
+                    $loginPostLogin.find('.submit').wrap('<div class="login-submit-wrapper"></div>');
+
+                    $('.login-submit-wrapper').click(function() {
+
+                        var $responseCode = $loginPostLogin.find('.response_body code');
+
+                        if($responseCode.length > 0) {
+                            $responseCode[0].innerText = '';
+                        }
+
+                        var watchForLoginResponse = setInterval(function() {
+                            var $responseCode = $loginPostLogin.find('.response_body code');
+                            if($responseCode.length > 0) {
+                                clearInterval(watchForLoginResponse);
+
+                                var textContent = $responseCode[0].textContent;
+                                if(textContent.indexOf('error') === -1) {
+                                    localStorage.setItem('swagger-jwt', textContent);
+                                    showToast('Updated Swagger localstorage JWT!');
+                                    populateAuthElements();
+                                } else {
+                                    showToast('Did not save JWT, try again');
+                                }
+                            }
+                        }, 1000);
+                    });
+
+                    populateAuthElements();
+                }, 1500);
+
+                // End autopopulate code
 
 
                 window.swaggerUi.load();


### PR DESCRIPTION
This script assumes you have a POST route named login. It listens for a response and as long as "error" isn't in the response it saves the text content of the response field in localstorage. It assumes that the only thing returned from the login route is the JWT, no JSON object.

This doesn't check which site you're using so if you load up a new API, the authentication fields will be autopopulated with a JWT from another project.