### PR TITLE
hapi v17

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "eslint-config-hapi"
+  "extends": "eslint-config-hapi",
+  "parserOptions": {
+      "ecmaVersion": 8
+  }
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A friendly, proven starting place for your next hapi plugin or deployment
 Lead Maintainer - [Devin Ivy](https://github.com/devinivy)
 
 **Features**
+ - Supports hapi v17+
  - Provides conventions for building plugins by mapping the entire hapi plugin API onto files and folders, using [haute-couture](https://github.com/devinivy/haute-couture).
  - Designed to allow you to deploy your plugin on its own or as part of a larger application.
  - Textbook integrations with Objection ORM, Swagger UI, and more via [flavors](#flavors).
@@ -29,7 +30,7 @@ $ npm start
 If everything goes well you should see this :surfer:
 
 ```bash
-> boilerplate-api@0.3.0 start /Users/maxfelker/my-project
+> boilerplate-api@2.0.0 start /Users/maxfelker/my-project
 > node server
 Server started at http://0.0.0.0:3000
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,22 +1,14 @@
 'use strict';
 
-const Package = require('../package.json');
 const HauteCouture = require('haute-couture');
+const Package = require('../package.json');
 
-exports.register = (server, options, next) => {
+exports.plugin = {
+    pkg: Package,
+    register: async (server, options) => {
 
-    HauteCouture.using()(server, options, (err) => {
+        // Custom plugin code can go here
 
-        if (err) {
-            return next(err);
-        }
-
-        // Custom stuff can go here!
-
-        return next();
-    });
-};
-
-exports.register.attributes = {
-    pkg: Package
+        await HauteCouture.using()(server, options);
+    }
 };

--- a/package.json
+++ b/package.json
@@ -8,20 +8,19 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "boom": "5.x.x",
-    "haute-couture": "2.x.x",
-    "joi": "12.x.x"
+    "boom": "7.x.x",
+    "haute-couture": "3.x.x",
+    "joi": "13.x.x"
   },
   "devDependencies": {
+    "code": "5.x.x",
     "confidence": "3.x.x",
     "dotenv": "4.x.x",
     "eslint": "4.x.x",
     "eslint-config-hapi": "11.x.x",
     "eslint-plugin-hapi": "4.x.x",
-    "glue": "4.x.x",
-    "hapi": "16.x.x",
-    "hoek": "4.x.x",
-    "lab": "14.x.x",
-    "labbable": "2.x.x"
+    "glue": "5.x.x",
+    "hapi": "17.x.x",
+    "lab": "15.x.x"
   }
 }

--- a/server/manifest.js
+++ b/server/manifest.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Dotenv = require('dotenv');
-const Hoek = require('hoek');
 const Confidence = require('confidence');
 
 // Pull .env into process.env
@@ -10,6 +9,8 @@ Dotenv.config({ path: `${__dirname}/.env` });
 // Glue manifest as a confidence store
 module.exports = new Confidence.Store({
     server: {
+        host: '0.0.0.0',
+        port: process.env.PORT || 3000,
         debug: {
             $filter: 'NODE_ENV',
             development: {
@@ -18,18 +19,12 @@ module.exports = new Confidence.Store({
             }
         }
     },
-    connections: [
-        {
-            host: '0.0.0.0',
-            port: Hoek.reach(process.env, 'PORT', { default: 3000 })
-        }
-    ],
-    registrations: [
-        {
-            plugin: {
-                register: '../lib', // Main plugin
+    register: {
+        plugins: [
+            {
+                plugin: '../lib', // Main plugin
                 options: {}
             }
-        }
-    ]
+        ]
+    }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -9,19 +9,14 @@ const Package = require('../package.json');
 
 // Test shortcuts
 
-const { before, describe, it } = exports.lab = Lab.script();
-const expect = Code.expect;
+const { describe, it } = exports.lab = Lab.script();
+const { expect } = Code;
 
 describe('Deployment', () => {
 
-    let server;
+    it('registers the main plugin.', async () => {
 
-    before(async () => {
-
-        server = await Server.deployment();
-    });
-
-    it('has the main plugin registered.', () => {
+        const server = await Server.deployment();
 
         expect(server.registrations[Package.name]).to.exist();
     });

--- a/test/index.js
+++ b/test/index.js
@@ -2,40 +2,27 @@
 
 // Load modules
 
+const Code = require('code');
 const Lab = require('lab');
+const Server = require('../server');
 const Package = require('../package.json');
-const LabbableServer = require('../server');
 
 // Test shortcuts
 
-const lab = exports.lab = Lab.script();
-const before = lab.before;
-const describe = lab.describe;
-const it = lab.it;
-const expect = Lab.expect;
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
 
-describe('Deployment server', () => {
+describe('Deployment', () => {
 
     let server;
 
-    before((done) => {
+    before(async () => {
 
-        LabbableServer.ready((err, srv) => {
-
-            if (err) {
-                return done(err);
-            }
-
-            server = srv;
-
-            return done();
-        });
+        server = await Server.deployment();
     });
 
-    it('has the main plugin registered.', (done) => {
+    it('has the main plugin registered.', () => {
 
         expect(server.registrations[Package.name]).to.exist();
-
-        return done();
     });
 });


### PR DESCRIPTION
- server/index.js no longer exports a singleton server via labbable, but rather an async function that returns a server.
- So, no more labbable (will be deprecated with a note in its readme)
- No more hoek needed as a deployment dep
- Added .hc.js for interop with the pal cli (will likely backport this simple change to the existing boilerplate)
- Unhandled rejections are treated the same as unhandled exceptions when running the deployment server (in line with node's deprecated treatment of unhandled rejections)
- Updated all deps