### PR TITLE
Switch knex to dependency for use in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "boom": "7.x.x",
     "haute-couture": "3.x.x",
     "joi": "13.x.x",
+    "knex": "0.15.x",
     "objection": "1.x.x",
     "schwifty": "4.x.x"
   },
@@ -26,7 +27,6 @@
     "hapi": "17.x.x",
     "hoek": "5.x.x",
     "hpal-debug": "1.x.x",
-    "knex": "0.15.x",
     "lab": "16.x.x",
     "sqlite3": "4.x.x",
     "toys": "2.x.x"


### PR DESCRIPTION
Yo! I did this because I got a module not found error when running the knex npm script after a production install (I think I did `NODE_ENV=production npm install`).

My bad if I misunderstood something! 🙏 🍹 