### PR TITLE
Replace nodemon command glob patterns with directory names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
         command: [
             "./node_modules/.bin/nodemon",
             "--watch",
-            "lib/**/*",
+            "lib",
             "--watch",
-            "server/**/*",
+            "server",
             "server/index.js"
         ]
         environment:


### PR DESCRIPTION
This fixes issue #92 .

Docker log output shows:
```
[nodemon] 2.0.4
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): lib/**/* server/**/*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node server/index.js`
Server started at http://0.0.0.0:3000
```